### PR TITLE
Allowed Location Usage  for iOS

### DIFF
--- a/frontend/ios/Runner/Info.plist
+++ b/frontend/ios/Runner/Info.plist
@@ -45,5 +45,7 @@
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>youSupply needs access to location to get client's coordinates for accurate and efficient delivery</string>
 </dict>
 </plist>


### PR DESCRIPTION
Added `NSLocationWhenInUseUsageDescription` in `info.plist` file that now asks user for Location permission rather than showing an error on the signup form

![Simulator Screenshot - iPhone 15 Pro - 2024-07-17 at 18 52 20](https://github.com/user-attachments/assets/ed38c03f-c87b-40c7-875d-fb609eab2b63)
